### PR TITLE
feat: Add support  for event.passThroughOnException

### DIFF
--- a/packages/types-cloudflare-worker/src/global.ts
+++ b/packages/types-cloudflare-worker/src/global.ts
@@ -26,6 +26,19 @@ declare global {
     cf: CloudflareRequestAttributes; // extends, therefore includes CloudflareRequestFeatures
   }
 
+  // Global augmentation of FetchEvent to provide additional lifecycle APIs.
+  // https://developers.cloudflare.com/workers/about/tips/fetch-event-lifecycle
+  interface FetchEvent {
+    /**
+     * Causes the script to “fail open” (meaning the execution of code is not halted)
+     * on unhandled exceptions. Instead of returning a runtime error response, the runtime
+     * proxies the request to its destination. To prevent JavaScript errors from causing
+     * entire requests to fail on uncaught exceptions, passThroughOnException() causes the
+     * Workers runtime to yield control to the origin server.
+     */
+    passThroughOnException(): void; // extends FetchEvent
+  }
+
   /**
    * Cloudflare Cache Storage
    *

--- a/src/helloworkerclass.ts
+++ b/src/helloworkerclass.ts
@@ -34,6 +34,9 @@ export class HelloWorkerClass {
   };
 
   public async handle(event: FetchEvent) {
+    if (typeof event.passThroughOnException === 'function') {
+      event.passThroughOnException();
+    }
     const cache = caches.default;
     const request = event.request;
 


### PR DESCRIPTION
Adds an new CloudflareWorkerFetchEvent interface which extends the
lib.webworker.ts FetchEvent.

It adds support for PassthroughOnException() which allows a worker to
"fail open".

see: https://developers.cloudflare.com/workers/reference/apis/fetch-event/