### PR TITLE
Update service worker mock

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -4294,6 +4294,45 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5302,6 +5341,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "realistic-structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
+      "integrity": "sha1-Gr6CrwuAzXsQn9r10pMIAyhS1F0=",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^3.0.2"
+      }
+    },
     "realpath-native": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -5578,13 +5626,13 @@
       "dev": true
     },
     "service-worker-mock": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.3.tgz",
-      "integrity": "sha512-LqTIVgm63EylNZldkpHxyC+iimxJwV6ymA4QaoOK+9d8Pt2kNcLgro96lH4Xgy0VYSzI5Qgr6eq2pikC0rxNCQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.4.tgz",
+      "integrity": "sha512-uA4qa/Wh2UmXLBnTCJuR6UCVHu3zzgWKToPcw9lCMKv1gBXr/sZYLls6FNd4+MD5KgWtfhmK+D9UeGmp2rQFow==",
       "dev": true,
       "requires": {
         "dom-urls": "^1.1.0",
-        "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
+        "shelving-mock-indexeddb": "^1.1.0",
         "url-search-params": "^0.10.0",
         "w3c-hr-time": "^1.0.1"
       }
@@ -5662,11 +5710,13 @@
       "dev": true
     },
     "shelving-mock-indexeddb": {
-      "version": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
-      "from": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
+      "integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
       "dev": true,
       "requires": {
-        "shelving-mock-event": "^1.0.8"
+        "realistic-structured-clone": "^1.0.1",
+        "shelving-mock-event": "^1.0.12"
       }
     },
     "signal-exit": {
@@ -6542,9 +6592,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg==",
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
+      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w==",
       "dev": true
     },
     "urix": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -26,7 +26,7 @@
     "cloudflare-worker-mock": "^1.1.0",
     "jest": "^24.9.0",
     "jest-fetch-mock": "^2.1.2",
-    "service-worker-mock": "^2.0.3",
+    "service-worker-mock": "^2.0.4",
     "ts-jest": "^24.2.0",
     "ts-loader": "^6.2.1",
     "tslint": "^5.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,7 +1449,7 @@
       "version": "file:packages/cloudflare-worker-mock",
       "dev": true,
       "requires": {
-        "service-worker-mock": "^2.0.3"
+        "service-worker-mock": "^2.0.4"
       },
       "dependencies": {
         "@udacity/types-cloudflare-worker": {
@@ -4344,6 +4344,45 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+      "dev": true
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "dev": true,
+      "requires": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "dev": true,
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5358,6 +5397,15 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "realistic-structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
+      "integrity": "sha1-Gr6CrwuAzXsQn9r10pMIAyhS1F0=",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^3.0.2"
+      }
+    },
     "realpath-native": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
@@ -5634,15 +5682,27 @@
       "dev": true
     },
     "service-worker-mock": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.3.tgz",
-      "integrity": "sha512-LqTIVgm63EylNZldkpHxyC+iimxJwV6ymA4QaoOK+9d8Pt2kNcLgro96lH4Xgy0VYSzI5Qgr6eq2pikC0rxNCQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.4.tgz",
+      "integrity": "sha512-uA4qa/Wh2UmXLBnTCJuR6UCVHu3zzgWKToPcw9lCMKv1gBXr/sZYLls6FNd4+MD5KgWtfhmK+D9UeGmp2rQFow==",
       "dev": true,
       "requires": {
         "dom-urls": "^1.1.0",
-        "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
+        "shelving-mock-indexeddb": "^1.1.0",
         "url-search-params": "^0.10.0",
         "w3c-hr-time": "^1.0.1"
+      },
+      "dependencies": {
+        "shelving-mock-indexeddb": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
+          "integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
+          "dev": true,
+          "requires": {
+            "realistic-structured-clone": "^1.0.1",
+            "shelving-mock-event": "^1.0.12"
+          }
+        }
       }
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "jest": "^24.9.0",
     "jest-fetch-mock": "^2.1.2",
     "prettier": "^1.19.1",
-    "service-worker-mock": "^2.0.3",
+    "service-worker-mock": "^2.0.4",
     "ts-jest": "^24.2.0",
     "ts-loader": "^6.2.1",
     "tslint": "^5.20.1",

--- a/packages/cloudflare-worker-mock/package-lock.json
+++ b/packages/cloudflare-worker-mock/package-lock.json
@@ -17,13 +17,55 @@
         "urijs": "^1.16.1"
       }
     },
+    "lodash._basefor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+      "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isplainobject": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+      "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+      "requires": {
+        "lodash._basefor": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.keysin": "^3.0.0"
+      }
+    },
+    "lodash.keysin": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+      "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+      "requires": {
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "realistic-structured-clone": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-1.0.1.tgz",
+      "integrity": "sha1-Gr6CrwuAzXsQn9r10pMIAyhS1F0=",
+      "requires": {
+        "lodash.isplainobject": "^3.0.2"
+      }
+    },
     "service-worker-mock": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.3.tgz",
-      "integrity": "sha512-LqTIVgm63EylNZldkpHxyC+iimxJwV6ymA4QaoOK+9d8Pt2kNcLgro96lH4Xgy0VYSzI5Qgr6eq2pikC0rxNCQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/service-worker-mock/-/service-worker-mock-2.0.4.tgz",
+      "integrity": "sha512-uA4qa/Wh2UmXLBnTCJuR6UCVHu3zzgWKToPcw9lCMKv1gBXr/sZYLls6FNd4+MD5KgWtfhmK+D9UeGmp2rQFow==",
       "requires": {
         "dom-urls": "^1.1.0",
-        "shelving-mock-indexeddb": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
+        "shelving-mock-indexeddb": "^1.1.0",
         "url-search-params": "^0.10.0",
         "w3c-hr-time": "^1.0.1"
       }
@@ -34,16 +76,18 @@
       "integrity": "sha512-2F+IZ010rwV3sA/Kd2hnC1vGNycsxeBJmjkXR8+4IOlv5e+Wvj+xH+A8Cv8/Z0lUyCut/HcxSpeDccYTVtnuaQ=="
     },
     "shelving-mock-indexeddb": {
-      "version": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
-      "from": "github:philipwalton/shelving-mock-indexeddb#621b7a275568051846d20e3e557fa1101418b1d1",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shelving-mock-indexeddb/-/shelving-mock-indexeddb-1.1.0.tgz",
+      "integrity": "sha512-akHJAmGL/dplJ4FZNxPxVbOxMw8Ey6wAnB9+3+GCUNqPUcJaskS55GijxZtarTfAYB4XQyu+FLtjcq2Oa3e2Lg==",
       "requires": {
-        "shelving-mock-event": "^1.0.8"
+        "realistic-structured-clone": "^1.0.1",
+        "shelving-mock-event": "^1.0.12"
       }
     },
     "urijs": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
-      "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.2.tgz",
+      "integrity": "sha512-s/UIq9ap4JPZ7H1EB5ULo/aOUbWqfDi7FKzMC2Nz+0Si8GiT1rIEaprt8hy3Vy2Ex2aJPpOQv4P4DuOZ+K1c6w=="
     },
     "url-search-params": {
       "version": "0.10.2",

--- a/packages/cloudflare-worker-mock/package.json
+++ b/packages/cloudflare-worker-mock/package.json
@@ -35,6 +35,6 @@
     "@udacity/types-service-worker-mock": "^1.0.0-rc8"
   },
   "dependencies": {
-    "service-worker-mock": "^2.0.3"
+    "service-worker-mock": "^2.0.4"
   }
 }


### PR DESCRIPTION
This PR updates service worker mock to `2.0.4` to include `Response.redirect` API introduced in  https://github.com/pinterest/service-workers/pull/128. 