### PR TITLE
fix: KV Namespace list method accepts an object

### DIFF
--- a/packages/cloudflare-worker-mock/src/index.ts
+++ b/packages/cloudflare-worker-mock/src/index.ts
@@ -96,9 +96,13 @@ export function makeCloudflareWorkerKVEnv(
       return Promise.resolve(undefined);
     },
     list(
-      _prefix: string,
-      _limit: number,
-      _cursor: string,
+      _params:
+        | {
+            prefix?: string | undefined;
+            limit?: number | undefined;
+            cursor?: string | undefined;
+          }
+        | undefined,
     ): Promise<CloudflareWorkerKVList> {
       return Promise.resolve({
         cursor: '1234567890',

--- a/packages/types-cloudflare-worker/src/global.ts
+++ b/packages/types-cloudflare-worker/src/global.ts
@@ -665,11 +665,11 @@ export interface CloudflareWorkerKV {
    *    cursor: "6Ck1la0VxJ0djhidm1MdX2FyD"
    *  }
    */
-  list(
-    prefix?: string,
-    limit?: number,
-    cursor?: string,
-  ): Promise<CloudflareWorkerKVList>;
+  list(params?: {
+    prefix?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<CloudflareWorkerKVList>;
 }
 
 /**

--- a/src/helloworkerclass.ts
+++ b/src/helloworkerclass.ts
@@ -60,9 +60,10 @@ export class HelloWorkerClass {
       const country = request.cf.country;
       countryCodeKV.put(country, '!', { expiration: 100 });
       const countryCode = await countryCodeKV.get(country);
+      const countryList = await countryCodeKV.list({ prefix: 'countries' });
 
       response = new Response(
-        `${body} ${request.cf.country} ${countryCode}!`,
+        `${body} ${request.cf.country} ${countryCode} ${countryList.keys[0].name}!`,
         this.responseInit,
       );
     }


### PR DESCRIPTION
The `KV.list()` method signature according to the [docs](https://developers.cloudflare.com/workers/runtime-apis/kv#listing-keys) is:
```js
NAMESPACE.list({prefix?: string, limit?: number, cursor?: string})
```

This solution seems correct to resolve #27 but I'm not 100% about it. Open to better ideas??? @adamjakab @marcelduin

